### PR TITLE
Add a thread sleep to avoid CPU spining.

### DIFF
--- a/src/main/java/org/wso2/diagnostics/watchers/logwatcher/LogWatcher.java
+++ b/src/main/java/org/wso2/diagnostics/watchers/logwatcher/LogWatcher.java
@@ -126,6 +126,8 @@ public class LogWatcher extends Thread {
                         position = 0;
                     } catch (FileNotFoundException e) {
                         log.error("Log file " + file.getPath() + " not found." , e);
+                        // sleep to avoid CPU spinning
+                        Thread.sleep(delay);
                     }
                     continue;
                 }


### PR DESCRIPTION
## Purpose
> When the error log file is deleted, a CPU spinning issue happens in the while loop.
Added a thread sleep similar to other places.
Fixes wso2/product-integrator-mi/issues/4851