### PR TITLE
Revert "Change what's written into log.txt"

### DIFF
--- a/src/main/assembly/resources/conf/config.toml
+++ b/src/main/assembly/resources/conf/config.toml
@@ -10,6 +10,7 @@ process_id_path = "../wso2carbon.pid"
 #server_name = "WSO2 Server"
 #server_version = "1.0.0"
 
+
 ## Action Executor Configurations
 
 # Example
@@ -57,8 +58,6 @@ action_executors = "ThreadDumper,MetricsSnapshot,ServerInfo"
 [log_watcher]
 enabled = "true"
 interval = "0.1"
-max_pre_error_context_size = "5"
-max_post_error_context_size = "5"
 
 # Custom Watcher Configurations
 [[custom_watchers]]
@@ -123,4 +122,3 @@ reload_time = "10"
 #directory = "diagnostics"
 #known_hosts_path = "/home/user/.ssh/known_hosts"
 #strict_host_key_checking = "yes" # or "no"
-

--- a/src/main/java/org/wso2/diagnostics/DiagnosticsApp.java
+++ b/src/main/java/org/wso2/diagnostics/DiagnosticsApp.java
@@ -44,9 +44,21 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
-import static java.rmi.server.LogStream.log;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.wso2.diagnostics.utils.Constants.*;
+
+import static org.wso2.diagnostics.utils.Constants.APP_HOME;
+import static org.wso2.diagnostics.utils.Constants.CONFIG_FILE_PATH;
+import static org.wso2.diagnostics.utils.Constants.CPU_WATCHER_ENABLED;
+import static org.wso2.diagnostics.utils.Constants.CPU_WATCHER_RETRY_COUNT;
+import static org.wso2.diagnostics.utils.Constants.CPU_WATCHER_INTERVAL;
+import static org.wso2.diagnostics.utils.Constants.CPU_WATCHER_THRESHOLD;
+import static org.wso2.diagnostics.utils.Constants.LOG_WATCHER_ENABLED;
+import static org.wso2.diagnostics.utils.Constants.LOG_WATCHER_INTERVAL;
+import static org.wso2.diagnostics.utils.Constants.MEMORY_WATCHER_ENABLED;
+import static org.wso2.diagnostics.utils.Constants.MEMORY_WATCHER_INTERVAL;
+import static org.wso2.diagnostics.utils.Constants.MEMORY_WATCHER_RETRY_COUNT;
+import static org.wso2.diagnostics.utils.Constants.MEMORY_WATCHER_THRESHOLD;
+import static org.wso2.diagnostics.utils.Constants.WATCHER_INITIAL_DELAY;
 
 /**
  * Diagnostic tool launcher.
@@ -82,11 +94,10 @@ public class DiagnosticsApp {
             boolean logWatcherEnabled = Boolean.parseBoolean(configMap.get(LOG_WATCHER_ENABLED).toString());
             if (logWatcherEnabled) {
                 double logWatcherInterval = Double.parseDouble(configMap.get(LOG_WATCHER_INTERVAL).toString());
-                int maxPreErrorContextSize = Integer.parseInt(configMap.get(MAX_PRE_ERROR_CONTEXT_SIZE).toString());
-                int maxPostErrorContextSize = Integer.parseInt(configMap.get(MAX_POST_ERROR_CONTEXT_SIZE).toString());
                 LogWatcher carbonLogTailor = new LogWatcher(appHome +
                         configMap.get(Constants.LOG_FILE_CONFIGURATION_FILE_PATH),
-                        new Interpreter(actionExecutorMap, regexMap, regexPatternReloadTime), logWatcherInterval, maxPreErrorContextSize, maxPostErrorContextSize);
+                        new Interpreter(actionExecutorMap, regexMap, regexPatternReloadTime), logWatcherInterval);
+                log.info("Listening to : " + configMap.get(Constants.LOG_FILE_CONFIGURATION_FILE_PATH));
                 carbonLogTailor.start();
             }
 

--- a/src/main/java/org/wso2/diagnostics/postexecutor/PostExecutorTask.java
+++ b/src/main/java/org/wso2/diagnostics/postexecutor/PostExecutorTask.java
@@ -21,7 +21,6 @@ package org.wso2.diagnostics.postexecutor;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.LinkedList;
 import java.util.TimerTask;
 
 import org.apache.logging.log4j.LogManager;
@@ -31,21 +30,19 @@ public class PostExecutorTask extends TimerTask {
 
     private static final Logger log = LogManager.getLogger(PostExecutorTask.class);
 
-    private final LinkedList<String> contextQueue;
+    private final String logLine;
     private final String folderPath;
 
-    public PostExecutorTask(LinkedList<String> contextQueue, String folderPath) {
+    public PostExecutorTask(String logLine, String folderPath) {
 
-        this.contextQueue = new LinkedList<>(contextQueue);
+        this.logLine = logLine;
         this.folderPath = folderPath;
     }
 
     @Override
     public void run() {
 
-        for (String logLine : contextQueue) {
-            this.writeLogLine(logLine);
-        }
+        this.writeLogLine(logLine);
         this.executeZipFileExecutor();
         this.deleteFolder();
     }
@@ -59,8 +56,8 @@ public class PostExecutorTask extends TimerTask {
     private void writeLogLine(String logLine) {
 
         try {
-            FileWriter writer = new FileWriter(folderPath + "/" + "log.txt", true);
-            writer.write(logLine + "\n");
+            FileWriter writer = new FileWriter(folderPath + "/" + "log.txt");
+            writer.write(logLine);
             writer.close();
         } catch (IOException e) {
             log.error("Error occurred while writing the log line to the file", e);

--- a/src/main/java/org/wso2/diagnostics/utils/Constants.java
+++ b/src/main/java/org/wso2/diagnostics/utils/Constants.java
@@ -47,8 +47,6 @@ public class Constants {
     // log_watcher constants
     public static final String LOG_WATCHER_ENABLED = "log_watcher.enabled";
     public static final String LOG_WATCHER_INTERVAL = "log_watcher.interval";
-    public static final String MAX_PRE_ERROR_CONTEXT_SIZE = "log_watcher.max_pre_error_context_size";
-    public static final String MAX_POST_ERROR_CONTEXT_SIZE = "log_watcher.max_post_error_context_size";
 
     // LogWatcher constants
     public static final String CUSTOM_WATCHERS = "custom_watchers";

--- a/src/main/java/org/wso2/diagnostics/watchers/logwatcher/Interpreter.java
+++ b/src/main/java/org/wso2/diagnostics/watchers/logwatcher/Interpreter.java
@@ -59,23 +59,23 @@ public class Interpreter {
         timer = new Timer();
     }
 
-    public void interpret(String errorLine, LinkedList<String> contextQueue) {
-        this.diagnoseError(errorLine, contextQueue);
+    public void interpret(String errorLine, String completeLog) {
+        this.diagnoseError(errorLine, completeLog);
     }
 
     /**
      * Method used to diagnose the error.
      *
      * @param errorLine error line
-     * @param contextQueue context queue
+     * @param completeLog complete log
      */
-    private void diagnoseError(String errorLine, LinkedList<String> contextQueue) {
-        this.createFolder(errorLine);
+    private void diagnoseError(String errorLine, String completeLog) {
+        this.createFolder();
         String regexPattern = findRegexPattern(errorLine);
         String[] executorsList = regexMap.get(regexPattern);
         if (executorsList != null && this.doAnalysis(executorsList, errorLine, regexPattern)) {
             try {
-                timer.schedule(new PostExecutorTask(contextQueue, folderPath), new Date(new Date().getTime() + 5000));
+                timer.schedule(new PostExecutorTask(completeLog, folderPath), new Date(new Date().getTime() + 5000));
             } catch (Exception e) {
                 log.error("Error while scheduling the post executor task", e);
             }
@@ -158,23 +158,16 @@ public class Interpreter {
 
     /**
      * Create folder for dump.
-     *
-     * @param errorLine The error line to include in the folder name
      */
-    public void createFolder(String errorLine) {
+    public void createFolder() {
 
         folderPath = (System.getProperty(Constants.APP_HOME) + "/temp/"); // get log file path
         File logFolder = new File(folderPath);
         if (!(logFolder.exists())) {
             logFolder.mkdir();
         }
-
-        // Clean up the errorLine to make it suitable for the folder name
-        String folderName = errorLine
-                .replaceAll("[\\\\/:*?\"<>|]", "_") // Replace illegal file characters
-                .replaceAll("\\s+", "_") // Replace whitespace with underscore
-                .substring(0, Math.min(500, errorLine.length())); // Limit length to avoid overly long folder names
-
+        // folder name set as timestamp
+        String folderName = new Timestamp(System.currentTimeMillis()).toString().replace(" ", "_");
         File dumpFolder = new File(folderPath + folderName);
         if (!dumpFolder.exists()) {
             try {

--- a/src/main/java/org/wso2/diagnostics/watchers/logwatcher/LogWatcher.java
+++ b/src/main/java/org/wso2/diagnostics/watchers/logwatcher/LogWatcher.java
@@ -24,27 +24,12 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 
-import java.util.LinkedList;
-import java.util.regex.Pattern;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class LogWatcher extends Thread {
 
     private static final Logger log = LogManager.getLogger(LogWatcher.class);
-    private static final long POST_ERROR_TIMEOUT_MILLIS = 5000; // 5 seconds default timeout
-    private static final Pattern LOG_LEVEL_PATTERN = Pattern.compile("(INFO|ERROR|WARN|FATAL|DEBUG)");
-    private static final int MAX_ERROR_CONTEXT_SIZE = 1000;
-
-    /**
-     * The processing state for log collection
-     */
-    private enum ProcessingState {
-        NORMAL,             // Collecting pre-error context
-        ERROR_COLLECTING,   // Collecting error and stack trace
-        POST_ERROR_COLLECTING // Collecting post-error context
-    }
 
     /**
      * The file which will be tailed.
@@ -58,14 +43,6 @@ public class LogWatcher extends Thread {
      * The interpreter to notify of events when tailing.
      */
     private final Interpreter interpreter;
-    /**
-     * Maximum amount of logs stored before the Error Line
-     */
-    private final int maxPreErrorContextSize;
-    /**
-     * Maximum amount of logs stored after the Error Line
-     */
-    private final int maxPostErrorContextSize;
 
     /**
      * Creates a Tailer for the given file.
@@ -73,27 +50,20 @@ public class LogWatcher extends Thread {
      * @param filepath   the file to follow.
      * @param interpreter   the TailerListener to use.
      * @param delay      the delay between checks of the file for new content in seconds.
-     * @param maxPreErrorContextSize    max log lines before the error
-     * @param maxPostErrorContextSize   max log lines after the error
      */
-    public LogWatcher(String filepath, Interpreter interpreter, double delay, int maxPreErrorContextSize, int maxPostErrorContextSize) {
+    public LogWatcher(String filepath, Interpreter interpreter, double delay) {
 
         this.file = new File(filepath);
         this.delay = Math.round(delay * 1000);
         this.interpreter = interpreter;
-        this.maxPreErrorContextSize = maxPreErrorContextSize;
-        this.maxPostErrorContextSize = maxPostErrorContextSize;
     }
+
     public void run() {
         try {
+
             RandomAccessFile reader = null;
             long position = 0;
-            LinkedList<String> contextQueue = new LinkedList<>();
-            ProcessingState currentState = ProcessingState.NORMAL;
-            String errorLine = "";
-            long errorTimestamp = 0;
-            int postErrorLogLevelCount = 0;
-
+            StringBuilder logBuilder = new StringBuilder(); // To accumulate log lines
             while (reader == null) {
                 try {
                     reader = new RandomAccessFile(file, "r");
@@ -108,7 +78,6 @@ public class LogWatcher extends Thread {
             }
             while (true) {
                 long fileLength = file.length();
-
                 if (fileLength < position) {
                     // File was rotated
                     log.info("Log file has been rotated. Reopening the file " + file.getPath());
@@ -117,12 +86,7 @@ public class LogWatcher extends Thread {
                         // Ensure that the old file is closed
                         closeQuietly(reader);
                         reader = new RandomAccessFile(file, "r");
-                        ProcessingResult result = readLines(reader, contextQueue, currentState,
-                                errorLine, errorTimestamp, postErrorLogLevelCount);
-                        currentState = result.state;
-                        errorLine = result.errorLine;
-                        errorTimestamp = result.errorTimestamp;
-                        postErrorLogLevelCount = result.postErrorLogLevelCount;
+                        readLines(reader, logBuilder);
                         position = 0;
                     } catch (FileNotFoundException e) {
                         log.error("Log file " + file.getPath() + " not found." , e);
@@ -133,31 +97,11 @@ public class LogWatcher extends Thread {
                 }
                 // Check if the file has been updated
                 if (fileLength > position) {
-                    // Read new content and update state
-                    ProcessingResult result = readLines(reader, contextQueue, currentState,
-                            errorLine, errorTimestamp, postErrorLogLevelCount);
-                    currentState = result.state;
-                    errorLine = result.errorLine;
-                    errorTimestamp = result.errorTimestamp;
-                    postErrorLogLevelCount = result.postErrorLogLevelCount;
+                    readLines(reader, logBuilder);
                     // Update the file length
                     position = fileLength;
                     // Move the file pointer to the end
                     reader.seek(fileLength);
-                }
-                // Check for timeout if we're in post-error collection state
-                if (currentState == ProcessingState.POST_ERROR_COLLECTING &&
-                        System.currentTimeMillis() - errorTimestamp > POST_ERROR_TIMEOUT_MILLIS) {
-
-                    log.debug("Post-error timeout reached. Processing error context.");
-                    interpreter.interpret(errorLine, contextQueue);
-
-                    // Reset state
-                    currentState = ProcessingState.NORMAL;
-                    contextQueue.clear();
-                    errorLine = "";
-                    errorTimestamp = 0;
-                    postErrorLogLevelCount = 0;
                 }
                 // Sleep for a short duration before checking for updates again
                 Thread.sleep(delay);
@@ -178,105 +122,31 @@ public class LogWatcher extends Thread {
         }
     }
 
-    /**
-     * Class to hold processing state results
-     */
-    private static class ProcessingResult {
-        ProcessingState state;
-        String errorLine;
-        long errorTimestamp;
-        int postErrorLogLevelCount;
+    private void readLines(RandomAccessFile reader, StringBuilder logBuilder) throws IOException {
 
-        ProcessingResult(ProcessingState state, String errorLine, long errorTimestamp, int postErrorLogLevelCount) {
-            this.state = state;
-            this.errorLine = errorLine;
-            this.errorTimestamp = errorTimestamp;
-            this.postErrorLogLevelCount = postErrorLogLevelCount;
-        }
-    }
-
-    private ProcessingResult readLines(RandomAccessFile reader, LinkedList<String> contextQueue,
-                                       ProcessingState currentState, String errorLine,
-                                       long errorTimestamp, int postErrorLogLevelCount) throws IOException {
-
+        // Read the new lines
         String line;
-
+        String errorLine = "";
         while ((line = reader.readLine()) != null) {
-            boolean isLogLevelLine = LOG_LEVEL_PATTERN.matcher(line).find();
-
-            switch (currentState) {
-                case NORMAL:
-                    if (isLogLevelLine) {
-                        // Manage pre-error context queue
-                        if (contextQueue.size() >= maxPreErrorContextSize) {
-                            contextQueue.removeFirst();
-                        }
-                        contextQueue.add(line);
-
-                        // Check if it's an error line
-                        if (line.contains("ERROR")) {
-                            currentState = ProcessingState.ERROR_COLLECTING;
-                            errorLine = line;
-                            errorTimestamp = System.currentTimeMillis();
-                        }
-                    } else {
-                        // Non-log level line in normal state, likely a stacktrace
-                        contextQueue.add(line);
-                    }
-                    break;
-
-                case ERROR_COLLECTING:
-                    // Check if we've reached the maximum error context size
-                    if (contextQueue.size() >= maxPreErrorContextSize + MAX_ERROR_CONTEXT_SIZE) {
-                        log.warn("Maximum error context size reached (" + MAX_ERROR_CONTEXT_SIZE +
-                                " lines). Switching to post-error collection to prevent memory issues.");
-                        // Force transition to post-error collecting state
-                        currentState = ProcessingState.POST_ERROR_COLLECTING;
-                        postErrorLogLevelCount = 0;
-                    } else {
-                        contextQueue.add(line);
-                    }
-
-                    if (isLogLevelLine) {
-                        // Found a new log level line - now start collecting post-error context
-                        currentState = ProcessingState.POST_ERROR_COLLECTING;
-                        postErrorLogLevelCount = 1; // Count this as first post-error log level line
-                    }
-                    break;
-
-
-                case POST_ERROR_COLLECTING:
-                    contextQueue.add(line);
-
-                    if (isLogLevelLine) {
-                        postErrorLogLevelCount++;
-
-                        // Check if we've collected enough post-error log lines
-                        if (postErrorLogLevelCount >= maxPostErrorContextSize) {
-                            interpreter.interpret(errorLine, contextQueue);
-
-                            // Reset state
-                            currentState = ProcessingState.NORMAL;
-                            contextQueue.clear();
-                            errorLine = "";
-                            errorTimestamp = 0;
-                            postErrorLogLevelCount = 0;
-
-                            // Add this new log level line as first in new context queue
-                            contextQueue.add(line);
-
-                            // Check if new line is an error (starting process again)
-                            if (line.contains("ERROR")) {
-                                currentState = ProcessingState.ERROR_COLLECTING;
-                                errorLine = line;
-                                errorTimestamp = System.currentTimeMillis();
-                            }
-                        }
-                    }
-                    break;
+            // Check if the line indicates the start of a stack trace
+            if (line.contains("ERROR") || line.contains("WARN")) {
+                if (logBuilder.length() == 0) {
+                    errorLine = line;
+                    logBuilder.append(line).append("\n");
+                } else {
+                    interpreter.interpret(errorLine, logBuilder.toString());
+                    logBuilder.setLength(0);
+                    errorLine = line;
+                    logBuilder.append(line).append("\n");
+                }
+            } else {
+                logBuilder.append(line).append("\n");
+            }
+            // If the logBuilder exceeds a threshold, interpret the log lines and clear the logBuilder
+            if (logBuilder.length() > 1000000) {
+                interpreter.interpret(errorLine, logBuilder.toString());
+                logBuilder.setLength(0);
             }
         }
-
-        return new ProcessingResult(currentState, errorLine, errorTimestamp, postErrorLogLevelCount);
     }
 }


### PR DESCRIPTION
Reverts wso2/runtime-diagnostic-tool#14

Reverting due to possible StringIndexOutOfBoundsException in Interpreter.createFolder()

  String folderName = errorLine
      .replaceAll("[\\\\/:*?\"<>|]", "_")
      .replaceAll("\\s+", "_")           // collapses multi-space → single char
      .substring(0, Math.min(500, errorLine.length()));  // BUG: uses original length

  The second replaceAll can produce a string shorter than errorLine.length() (multiple spaces collapse to one underscore). Calling substring(0, Math.min(500, errorLine.length())) can then
  throw StringIndexOutOfBoundsException.