### PR TITLE
Fix off-by-one error in diagnostic ZIP file retention logic

### DIFF
--- a/src/main/java/org/wso2/diagnostics/utils/FileUtils.java
+++ b/src/main/java/org/wso2/diagnostics/utils/FileUtils.java
@@ -176,7 +176,7 @@ public class FileUtils {
     public static void rotateFiles(File directory, int maxFiles) {
 
         File[] files = directory.listFiles();
-        Arrays.sort(files, Comparator.comparing(File::getName));
+        Arrays.sort(files, Comparator.comparingLong(File::lastModified));
         int fileCount = files.length;
         if (fileCount >= maxFiles) {
             for (int i = 0; i < fileCount - maxFiles; i++) {

--- a/src/main/java/org/wso2/diagnostics/utils/FileUtils.java
+++ b/src/main/java/org/wso2/diagnostics/utils/FileUtils.java
@@ -179,7 +179,7 @@ public class FileUtils {
         Arrays.sort(files, Comparator.comparing(File::getName));
         int fileCount = files.length;
         if (fileCount >= maxFiles) {
-            for (int i = 0; i < fileCount - maxFiles + 1; i++) {
+            for (int i = 0; i < fileCount - maxFiles; i++) {
                 files[i].delete();
             }
         }


### PR DESCRIPTION
## Purpose

The cleanup loop in FileUtils.java deleted one more file than required, causing max_count to always retain (max_count - 1) files instead of max_count. This also caused max_count = 1 to delete the newly created ZIP immediately.

Fixes: https://github.com/wso2/product-integrator-mi/issues/5013
